### PR TITLE
Netherlands - Remove GO-TV

### DIFF
--- a/channels.inc.php
+++ b/channels.inc.php
@@ -101,8 +101,3 @@ add_channel($chan_cl, "13 Teleseries", "13Teleseries", "https://www.13.cl/13t");
 */
 
 add_country($channels, "Chile", "cl", $chan_cl);
-
-$chan_nl = array();
-add_channel($chan_nl, "GO-TV [off-site]", "GO_TV", "https://www.go-rtv.nl/televisie");
-
-add_country($channels, "Netherlands", "nl", $chan_nl);

--- a/get.php
+++ b/get.php
@@ -296,9 +296,6 @@ else if ($channel == "Chilevision") {
 else if ($channel == "Canal13") {
     loc(canal13("bFL1IVq9RNGlWQaqgiFuNw"));
 }
-else if ($channel == "GO_TV") {
-    loc("https://gortv-m3u.7m.pl/grab.php");
-}
 else {
     header("Status: 404");
     header("Content-Type: text/plain");


### PR DESCRIPTION
Removes GO-TV because it was handled by a different domain that was not backed up.