### PR TITLE
Feature/add more joj channels

### DIFF
--- a/channels.inc.php
+++ b/channels.inc.php
@@ -26,7 +26,7 @@ add_channel($chan_sk, "Markiza Krimi", "Krimi", "https://media.cms.markiza.sk/em
 add_channel($chan_sk, "Markiza Klasik", "Klasik", "https://media.cms.markiza.sk/embed/klasik-live?autoplay=any");
 add_channel($chan_sk, "JOJ", "JOJ", "https://live.joj.sk/");
 add_channel($chan_sk, "JOJ Plus", "JOJP", "https://plus.joj.sk/live");
-add_channel($chan_sk, "JOJ Wau", "Wau", "https://wau.joj.sk/live");
+add_channel($chan_sk, "(JOJ) Wau", "Wau", "https://wau.joj.sk/live");
 add_channel($chan_sk, "JOJ 24", "JOJ24", "https://joj24.noviny.sk/");
 add_channel($chan_sk, "JOJ Šport", "JOJSport", "https://jojsport.joj.sk");
 add_channel($chan_sk, "Jojko", "Jojko", "https://jojko.joj.sk");

--- a/channels.inc.php
+++ b/channels.inc.php
@@ -22,13 +22,14 @@ add_channel($chan_sk, "TA3", "TA3", "https://www.ta3.com/live");
 add_channel($chan_sk, "Markiza", "Markiza", "https://media.cms.markiza.sk/embed/markiza-live?autoplay=any");
 add_channel($chan_sk, "(Markiza) Dajto", "Dajto", "https://media.cms.markiza.sk/embed/dajto-live?autoplay=any");
 add_channel($chan_sk, "(Markiza) Doma", "Doma", "https://media.cms.markiza.sk/embed/doma-live?autoplay=any");
-add_channel($chan_sk, "(Markiza) Krimi", "Krimi", "https://media.cms.markiza.sk/embed/krimi-live?autoplay=any");
-add_channel($chan_sk, "(Markiza) Klasik", "Klasik", "https://media.cms.markiza.sk/embed/klasik-live?autoplay=any");
+add_channel($chan_sk, "Markiza Krimi", "Krimi", "https://media.cms.markiza.sk/embed/krimi-live?autoplay=any");
+add_channel($chan_sk, "Markiza Klasik", "Klasik", "https://media.cms.markiza.sk/embed/klasik-live?autoplay=any");
 add_channel($chan_sk, "JOJ", "JOJ", "https://live.joj.sk/");
 add_channel($chan_sk, "JOJ Plus", "JOJP", "https://plus.joj.sk/live");
 add_channel($chan_sk, "JOJ Wau", "Wau", "https://wau.joj.sk/live");
 add_channel($chan_sk, "JOJ 24", "JOJ24", "https://joj24.noviny.sk/");
-
+add_channel($chan_sk, "JOJ Šport", "JOJSport", "https://jojsport.joj.sk");
+add_channel($chan_sk, "Jojko", "Jojko", "https://jojko.joj.sk");
 
 $slovakiaNote = array (
     "    <br>",
@@ -68,6 +69,11 @@ add_channel($chan_cz, "Prima Cool", "PrimaCool", "https://iprima.cz");
 add_channel($chan_cz, "Prima Zoom", "PrimaZoom", "https://iprima.cz");
 add_channel($chan_cz, "Prima Love", "PrimaLove", "https://iprima.cz");
 add_channel($chan_cz, "Prima Max", "PrimaMax", "https://iprima.cz");
+add_channel($chan_cz, "JOJ Family", "JOJFamily", "https://jojfamily.joj.cz");
+add_channel($chan_cz, "JOJ Cinema", "JOJCinema", "https://jojcinema.cz/");
+add_channel($chan_cz, "CS Film", "CSFilm", "https://csfilm.joj.cz");
+add_channel($chan_cz, "CS History", "CSHistory", "https://cshistory.joj.cz");
+add_channel($chan_cz, "CS Mystery", "CSMystery", "https://csmystery.joj.cz");
 
 $czechNote = array(
     "    <br>",

--- a/get.php
+++ b/get.php
@@ -172,6 +172,27 @@ else if ($channel == "Wau") {
 else if ($channel == "JOJ24") {
     m3u8_refer("https://live.cdn.joj.sk/live/andromeda/joj_news-1080.m3u8", "https://media.joj.sk/");
 }
+else if ($channel == "JOJFamily") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/family-1080.m3u8", "https://media.joj.sk/");
+}
+else if ($channel == "JOJCinema") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/cinema-1080.m3u8", "https://media.joj.sk/");
+}
+else if ($channel == "JOJSport") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/joj_sport-1080.m3u8", "https://media.joj.sk/");
+}
+else if ($channel == "Jojko") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/jojko-1080.m3u8", "https://media.joj.sk/");
+}
+else if ($channel == "CSFilm") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/cs_film-1080.m3u8", "https://media.joj.sk/");
+}
+else if ($channel == "CSHistory") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/cs_history-1080.m3u8", "https://media.joj.sk/");
+}
+else if ($channel == "CSMystery") {
+    m3u8_refer("https://live.cdn.joj.sk/live/andromeda/cs_mystery-1080.m3u8", "https://media.joj.sk/");
+}
 else if ($channel == "Nova") {
     m3u8_refer(nova_url("nova-"), "https://media.cms.nova.cz/");
 }


### PR DESCRIPTION
- adds missing joj group channels
  - from joj.sk
    - Jojko
    - JOJ Šport
  - from joj.cz 
    - JOJ Family
    - JOJ Cinema
    - CS Film
    - CS History
    - CS Mystery
- renames **JOJ Wau** to **(JOJ) Wau** as the channel doesn't have JOJ in its name (yet)
- renames **(Markiza) Krimi** to **Markiza Krimi** and **(Markiza) Klasik** to **Markiza Klasik** as these are with 'Markiza' in its name (Dajto and Doma are't)